### PR TITLE
Export project type

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,10 +172,16 @@
 ** Contributing guidelines
 
    Currently beta quality. Looking forward to ideas and feedback. If
-   you're raising a PR, please add a test. Not having types to catch
+   you're raising a PR, please add a test. (Please see [[** Testing Framework]] Not having types to catch
    your errors are hard - even if lisp somehow makes it bearable,
    let's ensure we still try to catch errors early!
     
+** Testing Framework
+
+   This project uses [[https://www.gnu.org/software/emacs/manual/html_node/ert/Running-Tests-Interactively.html#Running-Tests-Interactively][ERT]] for unit tests and some end-to-end
+   tests. Testing during development can be convenient with ERT's
+   interactive mode - =M-x ert=.
+
 ** License
 
    MIT licensed. Please see LICENSE for more details

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -32,7 +32,7 @@
 (defvar esy-command "esy"
   "The 'esy' command. Can be full path to the esy binary.")
 
-(defvar esy-mode-callback (lambda ())
+(defvar esy-mode-callback (lambda (project-type))
   "The callback that can be run once an esy project is initialised. Common use case is to enable ask lsp client to connect to the server (since this can only be done after the esy project is ready)")
 
 (defun esy/f--read (file-path)
@@ -300,6 +300,7 @@ package.json or not"
   "Initialises esy-mode with necessary config. Relies on global vars like esy-command esy-mode-callback"
  (make-local-variable 'process-environment)
  (make-local-variable 'exec-path)
+ (make-local-variable 'merlin-command)
  (if (file-exists-p esy-command)
      (let ((esy-bin-dir (file-name-directory esy-command)))
        (add-to-list 'exec-path esy-bin-dir)
@@ -334,7 +335,7 @@ package.json or not"
           		 (callback
           		  (lambda (config-plist)
           		    (setq merlin-command (executable-find "ocamlmerlin"))
-          		    (funcall esy-mode-callback))))
+          		    (funcall esy-mode-callback project-type))))
           	     (cond ((eq project-type 'opam)
           		    (esy/setup--opam project
           				     callback))


### PR DESCRIPTION
This helps in the users configuring things like lsp-clients
accordingly.

Example (warn: changes are not buffer local)

	       (setq esy-mode-callback
		     (lambda (esy-project-type)
		       (cond ((eq esy-project-type 'opam)
			      (lsp-register-client
			       (make-lsp-client
				:new-connection (lsp-stdio-connection '("opam" "exec" "--" "ocamllsp"))
				:major-modes '(reason-mode tuareg-mode)
				:server-id 'opam-ocaml-lsp)))
			     ((eq esy-project-type 'esy)
			      (lsp-register-client
			       (make-lsp-client
				:new-connection (lsp-stdio-connection '("esy" "ocamllsp"))
				:major-modes '(reason-mode tuareg-mode)
				:server-id 'esy-ocaml-lsp)))
			     ((eq esy-project-type 'npm) (message "TODO: configure lsp for esy JS project")))
		       (message "esy-mode ready")))