### PR TITLE
Improvements 20231115

### DIFF
--- a/esy-mode.el
+++ b/esy-mode.el
@@ -354,6 +354,7 @@ it looks for
 for development"
   (if (esy/project--fetched-p project)
       (let* ((command-env (esy/command-env--of-project project)))
+	(message "setting process-environment")
 	  (setq process-environment
 	    (esy/command-env--to-process-environment
 	     command-env))

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -317,7 +317,7 @@ that can be assigned to 'process-environment"
   "Given a list of environment variables (ex: \'(\"PATH=/foo/bar\"
 \"LDFLAGS=some_values\")\'), gets just exec-path" 
   (let* ((path-env-str-list
-	  (seq-filter (lambda (s) (string-match "^path=" s)) penv))
+	  (seq-filter (lambda (s) (string-match "^PATH=" s)) penv))
 	 (path-env-str-key-value (car path-env-str-list))
 	 (path-env-str (nth 1 (split-string path-env-str-key-value "="))))
     (split-string path-env-str

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -236,9 +236,10 @@ later be used to obtain more info about the esy project"
 
 (defun esy/cached-project--of-buffer (buffer)
   "Looks up the project db first, then call esy/project--of-buffer if necessary"
-  (let* ((project-root (esy/internal--root-of-cwd (esy/internal--cwd-of-buffer buffer)))
-	(cached-project (esy/project--read-db project-root)))
-    (if cached-project cached-project (esy/project--of-buffer buffer))))
+  (let* ((project-root (esy/internal--root-of-cwd (esy/internal--cwd-of-buffer buffer))))
+    (if project-root
+	(let* ((cached-project (esy/project--read-db project-root)))
+	  (if cached-project cached-project (esy/project--of-buffer buffer))))))
 
 (defun esy/project--fetched-p (project)
   "Returns if a given project's sources have been solved and fetched. This
@@ -780,8 +781,11 @@ it returns if the project is ready for development"
     (if (esy-mode-init)
 	(condition-case
 	 nil
-	 (let* ((project (esy/cached-project--of-buffer (current-buffer))))
-      (esy/project--persist project)
+	    (let* ((cached-project (esy/cached-project--of-buffer (current-buffer)))
+		   (project (if cached-project cached-project (esy/project--of-buffer (current-buffer)))))
+
+	      (if project (esy/project--persist project))
+
       (if (esy/project--p project)
 	  (progn
 	    

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -40,6 +40,9 @@
 (defvar esy-command "esy"
   "The 'esy' command. Can be full path to the esy binary.")
 
+(defvar esy-package-command "esy-package"
+  "Command (that the default shell can resolve by itself, if full path isn't provided) to package libraries not written in Reason/OCaml. Usually, C")
+
 (defvar esy-mode-callback (lambda (&optional project-type) (message (format "%s project ready for development" project-type)))
   "The callback that can be run once an esy project is initialised.
 Common use case is to enable ask lsp client to connect to the server
@@ -586,6 +589,34 @@ This assumes that this value comes from `esy status`'s output"
       ("n" "Run npm-release"       esy-npm-release)
       ("t" "Test"       esy-test)
     ]])
+
+(defun esy-package--run (args)
+  "Runs esy-package command in *esy-package* buffer"
+  (let* ((command (if args
+		     (push esy-package-command args)
+		    (list esy-package-command))))
+    (apply
+     #'start-process
+     (append
+      '("esy-package-<todo-buffer-name>" "*esy-package-<todo-buffer-name>*" )
+      command) '(:stderr "*esy-package-stderr<todo-buffer-name>*"))))
+
+(esy-package--run '("fetch"))
+    
+
+
+
+  (run-cmd
+   "*esy-package*"
+   command
+   (lambda ()
+     (with-current-buffer
+	 "*esy-package*"
+       (callback))))))
+
+(defun esy-package-fetch ()
+  "Entrypoint defun to fetch a package tarball mentioned in the current manifest"
+  (run-esy-package '("fetch")))
 
 (defun esy ()
   "Entrypoint function to the esy-mode interactive functions

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -148,7 +148,7 @@ global toolchain could be loaded"
   "Given buffer, finds tries to find the cwd of the file attached to the buffer.
 Returns nil, if it fails"
   (let* ((file-name (esy/internal-buffer-file-name buffer)))
-    (if file-name (file-name-directory file-name) nil)))
+    (if file-name (file-name-directory file-name) default-directory)))
 
 (defun esy/internal--root-of-cwd (cwd)
   "Given current working directory, get\'s project root using \'esy status\'

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -371,7 +371,7 @@ it looks for
 	(if esy--is-windows
             (setq find-program "esy b find" grep-program "esy b grep"))
 	(funcall callback
-		 (esy/setup--esy-get-available-tools project)))
+		 (esy/setup--esy-get-available-tools)))
   (message "Project not ready for development! Please run esy")))
 
 (defun esy/setup--esy (project callback)

--- a/esy-mode.el
+++ b/esy-mode.el
@@ -372,7 +372,7 @@ for development"
 	(if (string= system-type "windows-nt")
             (setq find-program "esy b find" grep-program "esy b grep"))
 	(funcall callback
-		 (esy/setup--esy-get-available-tools project)))
+		 (esy/setup--esy-get-available-tools)))
     nil))
 
 (defun esy/setup--opam (project callback)

--- a/tests/esy.el
+++ b/tests/esy.el
@@ -312,3 +312,10 @@ project with a package.json (but no esy field in it)"
 			    (should (not (esy/project--ready-p project)))))
 		  :teardown (lambda (fixture-project-path)
 			       (delete-directory fixture-project-path t))))
+
+(ert-deftest
+    test-esy/esy/internal--is-file-from-source-cache
+    ()
+    "Tests if esy/internal--is-file-from-source-cache identifies file paths from source cache"
+    (should (not (esy/internal--is-file-from-source-cache "~/foo.c")))
+    (should (esy/internal--is-file-from-source-cache "~/.esy/source/i/esy_gmp__45eab250/foo.c")))


### PR DESCRIPTION
1. Use async [`aio`](https://github.com/skeeto/emacs-aio)
2. Fix for case when package being view is from esy source cache. Run `esy status` status there is meaningless.
3. Adds `esy-get-build-dir`
4. Adds [get-available-tools funcall](https://github.com/ManasJayanth/esy-mode/commit/bd893fa1901dc79614e10eb8701767901c0ba1d5)